### PR TITLE
Change url in redirect to slug

### DIFF
--- a/index.js
+++ b/index.js
@@ -114,7 +114,7 @@ module.exports = {
       }).toObject(function(err, result) {
         if(result) {
           if(result.urlType == 'internal' && result._newPage) {
-            return req.res.redirect(result._newPage._url);
+            return req.res.redirect(result._newPage.slug);
           } else if(result.urlType == 'external' && result.externalUrl.length) {
             return req.res.redirect(result.externalUrl);
           }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "apostrophe-redirects",
-  "version": "0.6.1",
+  "version": "0.6.2",
   "description": "Allows admins to create redirects within an Apostrophe site",
   "main": "index.js",
   "scripts": {


### PR DESCRIPTION
Running into an issue with `_url` when a site prefix is set. For example `/my-prefix/old-url` will redirect to `/my-prefix/my-prefix/old-url`.